### PR TITLE
fixes ruby syntax in formula

### DIFF
--- a/mocli.rb
+++ b/mocli.rb
@@ -27,7 +27,7 @@ class Mocli < Formula
         url "https://github.com/mogenius/homebrew-mocli/releases/download/v1.7.9/mocli-v1.7.9-linux-386.tar.gz"
         sha256 "7d3bc9ed5c8abab6b275c5a0ce41d573f8f13d61753f7d5047cf622669f4c321"
       end
-    elif Hardware::CPU.arm?
+    elsif Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
         url "https://github.com/mogenius/homebrew-mocli/releases/download/v1.7.9/mocli-v1.7.9-linux-arm64.tar.gz"
         sha256 "afac0baaebea655cd5373f9b8deff971120f0b38f07105656b78b293bf7776ea"


### PR DESCRIPTION
Hello, on my system 
```$ uname -a
Linux DESKTOP-S7UJ8HE 5.15.146.1-microsoft-standard-WSL2 #1 SMP Thu Jan 11 04:09:03 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux


$ ruby --version
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux-gnu]


$ brew --version
Homebrew 4.2.18-71-g47c2c6d
Homebrew/homebrew-core (git revision 911c679f0c8; last commit 2024-04-15)
Homebrew/homebrew-cask (git revision 14b7f45e50; last commit 2024-04-15)
``` 

The syntax error in ruby leads to a failed install: 
```bash 
$brew install mocli
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Error: mogenius/mocli/mocli: undefined method `elif' for Formulary::FormulaNamespace409a4f17b471a0083b3ab9197d06bafcdd2f65fc4a2ce3ff9f403738d40c614c::Mocli:Class
Did you mean?  elsif
``` 

Tested locally by changing `/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/mogenius/homebrew-mocli/mocli.rb` after which the install is successful and mocli works. 

